### PR TITLE
update Wikipedia link for Steam

### DIFF
--- a/www/logos/steampowered/index.md
+++ b/www/logos/steampowered/index.md
@@ -7,5 +7,5 @@ sort: steam
 title: Steam
 twitter: steam_games
 website: https://store.steampowered.com/
-wikipedia: https://en.wikipedia.org/wiki/Steam_(software)
+wikipedia: https://en.wikipedia.org/wiki/Steam_(service)
 ---


### PR DESCRIPTION
‘Steam (software)’ redirects to ‘Steam (service)’.